### PR TITLE
[CPU BF16] Support for Bfloat16 type was added to the MVN layer.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <mkldnn_types.h>
 #include <mkldnn_extension_utils.h>
+#include "ngraph/type/bfloat16.hpp"
 #include <legacy/ie_layers_internal.hpp>
 #include "ie_parallel.hpp"
 #include <algorithm>
@@ -31,6 +32,15 @@ using namespace mkldnn::impl::utils;
 using namespace Xbyak;
 
 #define GET_OFF(field) offsetof(jit_mvn_call_args, field)
+
+// some utility functions
+static inline bool isFloatCompartible(Precision prc) {
+    return Precision::FP32 == prc || Precision::BF16 == prc;
+}
+
+static inline bool isFloatCompartible(memory::data_type type) {
+    return memory::f32 == type || memory::bf16 == type;
+}
 
 // normalize_variance = false : src->mean
 // normalize_variance = true : src+mean->variance:sqr(x-mean)
@@ -89,13 +99,13 @@ struct jit_uni_mvn_mean_variance_kernel_f32 : public jit_uni_mvn_mean_variance_k
                 load_vector(vmm_val, ptr[reg_src], jcp_.src_dt);
 
                 if (jcp_.normalize_variance) {
-                    if (jcp_.src_dt != memory::f32)
+                    if (!isFloatCompartible(jcp_.src_dt))
                         uni_vcvtdq2ps(vmm_val, vmm_val);
 
                     uni_vsubps(vmm_val, vmm_val, vmm_mean);
                     uni_vfmadd231ps(vmm_variance, vmm_val, vmm_val);
                 } else {
-                    if (jcp_.src_dt != memory::f32)
+                    if (!isFloatCompartible(jcp_.src_dt))
                         uni_vpaddd(vmm_sum, vmm_sum, vmm_val);
                     else
                         uni_vaddps(vmm_sum, vmm_sum, vmm_val);
@@ -139,7 +149,7 @@ struct jit_uni_mvn_mean_variance_kernel_f32 : public jit_uni_mvn_mean_variance_k
 
                     uni_vmovups(ptr[reg_variance], vmm_variance);
                 } else {
-                    if (jcp_.src_dt != memory::f32)
+                    if (!isFloatCompartible(jcp_.src_dt))
                         uni_vcvtdq2ps(vmm_sum, vmm_sum);
 
                     if (!jcp_.planar_layout && !jcp_.across_channels) {
@@ -199,6 +209,10 @@ private:
                 break;
             case memory::u8:
                 uni_vpmovzxbd(vmm_src, op);
+                break;
+            case memory::bf16:
+                vpmovzxwd(vmm_src, op);
+                uni_vpslld(vmm_src, vmm_src, 16);
                 break;
             default:
                 assert(!"unknown dst_dt");
@@ -349,11 +363,15 @@ private:
             case memory::u8:
                 uni_vpmovzxbd(vmm_src, op);
                 break;
+            case memory::bf16:
+                vpmovzxwd(vmm_src, op);
+                uni_vpslld(vmm_src, vmm_src, 16);
+                break;
             default:
                 assert(!"unknown dst_dt");
         }
 
-        if (src_dt != memory::f32)
+        if (!isFloatCompartible(src_dt))
             uni_vcvtdq2ps(vmm_src, vmm_src);
     }
 
@@ -363,6 +381,9 @@ private:
 
         if (dst_dt == memory::f32) {
             uni_vmovups(op, vmm_dst);
+        } else if (dst_dt == memory::bf16) {
+            vcvtneps2bf16(ymm_dst, vmm_dst);
+            uni_vmovups(op, ymm_dst);
         } else if (dst_dt == memory::u8) {
             uni_vcvtps2dq(vmm_dst, vmm_dst);
             if (isa == cpu::avx512_common) {
@@ -478,8 +499,21 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
 
     if (getParentEdgeAt(0)->getDims().ndims() < 4 || getParentEdgeAt(0)->getDims().ndims() > 5
         || across_channels != 0 || normalize_variance != 1) {
-        inputPrecision = Precision::FP32;
-        outputPrecision = Precision::FP32;
+        if (!isFloatCompartible(inputPrecision)) {
+            inputPrecision = Precision::FP32;
+        }
+        if (!isFloatCompartible(outputPrecision)) {
+            outputPrecision = Precision::FP32;
+        }
+    }
+
+    if (!mayiuse(avx512_core_bf16)) {
+        bool hasBF16 = false;
+        if (inputPrecision == Precision::BF16)
+            hasBF16 = true;
+
+        if (outputPrecision == Precision::BF16 || hasBF16)
+            THROW_IE_EXCEPTION << "MVN node with name `" << getName() << "` doesn't support BF16 precision on this target.";
     }
 
     auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(inputPrecision);
@@ -501,39 +535,50 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
     config.inConfs[0].inPlace = -1;
     config.outConfs[0].inPlace = canBeInplace ? 0 : -1;
 
-    auto pushDesc = [&](memory::format format) {
+    auto pushDesc = [&](memory::format format, impl_desc_type impl_type) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, format);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), outputDataType, format);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, format});
+        supportedPrimitiveDescriptors.push_back({config, impl_type, format});
     };
+
+    impl_desc_type impl_type;
+    if (mayiuse(cpu::avx512_common)) {
+        impl_type = impl_desc_type::jit_avx512;
+    } else if (mayiuse(cpu::avx2)) {
+        impl_type = impl_desc_type::jit_avx2;
+    } else if (mayiuse(cpu::sse42)) {
+        impl_type = impl_desc_type::jit_sse42;
+    } else {
+        impl_type = impl_desc_type::ref;
+    }
 
     if (across_channels == 0 && normalize_variance == 1) {
         if (getParentEdgeAt(0)->getDims().ndims() == 4) {
-            pushDesc(memory::nhwc);
+            pushDesc(memory::nhwc, impl_type);
         } else if (getParentEdgeAt(0)->getDims().ndims() == 5) {
-            pushDesc(memory::ndhwc);
+            pushDesc(memory::ndhwc, impl_type);
         }
     }
 
-    if (inputPrecision == Precision::FP32 && outputPrecision == Precision::FP32) {
-        if (getParentEdgeAt(0)->getDims().ndims() == 4) {
-            if (mayiuse(cpu::avx512_common)) {
-                pushDesc(memory::nChw16c);
-            } else if (mayiuse(cpu::avx2) || mayiuse(cpu::sse42)) {
-                pushDesc(memory::nChw8c);
+    if (isFloatCompartible(inputPrecision) && isFloatCompartible(outputPrecision)) {
+        if (impl_desc_type::jit_avx512 == impl_type) {
+            if (getParentEdgeAt(0)->getDims().ndims() == 4) {
+                pushDesc(memory::nChw16c, impl_type);
+            } else if (getParentEdgeAt(0)->getDims().ndims() == 5) {
+                pushDesc(memory::nCdhw16c, impl_type);
             }
-        } else if (getParentEdgeAt(0)->getDims().ndims() == 5) {
-            if (mayiuse(cpu::avx512_common)) {
-                pushDesc(memory::nCdhw16c);
-            } else if (mayiuse(cpu::avx2) || mayiuse(cpu::sse42)) {
-                pushDesc(memory::nCdhw8c);
+        } else if (impl_desc_type::jit_avx2 ==  impl_type || impl_desc_type::jit_sse42 == impl_type) {
+            if (getParentEdgeAt(0)->getDims().ndims() == 4) {
+                pushDesc(memory::nChw8c, impl_type);
+            } else if (getParentEdgeAt(0)->getDims().ndims() == 5) {
+                pushDesc(memory::nCdhw8c, impl_type);
             }
         }
 
         if (fusedWith.empty()) {
             if (canBeInplace)
                 config.inConfs[0].inPlace = 0;
-            pushDesc(MKLDNNMemory::GetPlainFormat(getChildEdgeAt(0)->getDims()));
+            pushDesc(MKLDNNMemory::GetPlainFormat(getChildEdgeAt(0)->getDims()), impl_type);
         }
     }
 }
@@ -672,11 +717,26 @@ void MKLDNNMVNNode::execute(mkldnn::stream strm) {
 
     Layout layout = getParentEdgeAt(0)->getDesc().getLayout();
 
-    auto src_data = reinterpret_cast<const float *>(srcMemPtr->GetData());
-    auto dst_data = reinterpret_cast<float *>(dstMemPtr->GetData());
-
     if (layout == C || layout == NC || layout == CHW || layout == NCHW || layout == NCDHW) {
-        mvn_pln(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+        if (input_prec == Precision::FP32) {
+            auto src_data = reinterpret_cast<float*>(srcMemPtr->GetData());
+            if (output_prec == Precision::FP32) {
+                auto dst_data = reinterpret_cast<float*>(dstMemPtr->GetData());
+                mvn_pln(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (output_prec == Precision::BF16) {
+                auto dst_data = reinterpret_cast<ngraph::bfloat16*>(dstMemPtr->GetData());
+                mvn_pln(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            }
+        } else if (input_prec == Precision::BF16) {
+            auto src_data = reinterpret_cast<ngraph::bfloat16*>(srcMemPtr->GetData());
+            if (output_prec == Precision::FP32) {
+                auto dst_data = reinterpret_cast<float*>(dstMemPtr->GetData());
+                mvn_pln(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (output_prec == Precision::BF16) {
+                auto dst_data = reinterpret_cast<ngraph::bfloat16*>(dstMemPtr->GetData());
+                mvn_pln(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            }
+        }
     } else {
         if (output_prec == Precision::U8) {
             auto dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
@@ -689,6 +749,9 @@ void MKLDNNMVNNode::execute(mkldnn::stream strm) {
             } else if (input_prec == Precision::FP32) {
                 auto src_data = reinterpret_cast<const float *>(srcMemPtr->GetData());
                 mvn_blk<float, uint8_t>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::BF16) {
+                auto src_data = reinterpret_cast<const ngraph::bfloat16 *>(srcMemPtr->GetData());
+                mvn_blk<ngraph::bfloat16, uint8_t>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
             }
         } else if (output_prec == Precision::I8) {
             auto dst_data = reinterpret_cast<int8_t *>(dstMemPtr->GetData());
@@ -701,6 +764,9 @@ void MKLDNNMVNNode::execute(mkldnn::stream strm) {
             } else if (input_prec == Precision::FP32) {
                 auto src_data = reinterpret_cast<const float *>(srcMemPtr->GetData());
                 mvn_blk<float, int8_t>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::BF16) {
+                auto src_data = reinterpret_cast<const ngraph::bfloat16 *>(srcMemPtr->GetData());
+                mvn_blk<ngraph::bfloat16, int8_t>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
             }
         } else if (output_prec == Precision::FP32) {
             auto dst_data = reinterpret_cast<float *>(dstMemPtr->GetData());
@@ -713,6 +779,25 @@ void MKLDNNMVNNode::execute(mkldnn::stream strm) {
             } else if (input_prec == Precision::FP32) {
                 auto src_data = reinterpret_cast<float *>(srcMemPtr->GetData());
                 mvn_blk<float, float>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::BF16) {
+                auto src_data = reinterpret_cast<const ngraph::bfloat16*>(srcMemPtr->GetData());
+                mvn_blk<ngraph::bfloat16, float>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            }
+
+        } else if (output_prec == Precision::BF16) {
+            auto dst_data = reinterpret_cast<ngraph::bfloat16*>(dstMemPtr->GetData());
+            if (input_prec == Precision::U8) {
+                auto src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetData());
+                mvn_blk<uint8_t, ngraph::bfloat16>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::I8) {
+                auto src_data = reinterpret_cast<const int8_t *>(srcMemPtr->GetData());
+                mvn_blk<int8_t, ngraph::bfloat16>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::FP32) {
+                auto src_data = reinterpret_cast<float *>(srcMemPtr->GetData());
+                mvn_blk<float, ngraph::bfloat16>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
+            } else if (input_prec == Precision::BF16) {
+                auto src_data = reinterpret_cast<const ngraph::bfloat16*>(srcMemPtr->GetData());
+                mvn_blk<ngraph::bfloat16, ngraph::bfloat16>(src_data, dst_data, getParentEdgeAt(0)->getDesc().getDims());
             }
         }
     }
@@ -731,7 +816,8 @@ std::tuple<size_t, size_t, size_t, size_t, size_t> MKLDNNMVNNode::get5dShapes(co
     return shapes;
 }
 
-void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVector& dims) {
+template <typename in_data_t, typename out_data_t>
+void MKLDNNMVNNode::mvn_pln(const in_data_t* src_data, out_data_t* dst_data, const SizeVector& dims) {
     size_t blk_size = 1;  // blk size in vmm
     if (mayiuse(cpu::avx512_common)) {
         blk_size = 16;
@@ -763,7 +849,7 @@ void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVe
                     auto arg = jit_mvn_call_args();
                     arg.src = src_data + cc;
                     arg.sum = static_cast<float*>(&mean_internal);
-                    arg.src_stride = static_cast<size_t>(blk_size * sizeof(float));
+                    arg.src_stride = static_cast<size_t>(blk_size * sizeof(in_data_t));
                     arg.work_amount = static_cast<size_t>(C2 / blk_size);
                     (*mvn_mean_kernel)(&arg);
                     for (size_t tail = tail_across_channels; tail < C2; tail++) {
@@ -795,7 +881,7 @@ void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVe
                         arg.src = src_data + cc;
                         arg.mean = static_cast<float*>(&mean);
                         arg.variance = static_cast<float*>(&variance_internal);
-                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(float));
+                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(in_data_t));
                         arg.work_amount = static_cast<size_t>(C2 / blk_size);
                         (*mvn_variance_kernel)(&arg);
 
@@ -824,8 +910,8 @@ void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVe
                         arg.dst = dst_data + cc;
                         arg.mean = static_cast<float*>(&mean);
                         arg.variance = static_cast<float*>(&variance);
-                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(float));
-                        arg.dst_stride = static_cast<size_t>(blk_size * sizeof(float));
+                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(in_data_t));
+                        arg.dst_stride = static_cast<size_t>(blk_size * sizeof(out_data_t));
                         arg.work_amount = static_cast<size_t>(C2 / blk_size);
                         (*mvn_kernel)(&arg);
 
@@ -850,8 +936,8 @@ void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVe
                         arg.src = src_data + cc;
                         arg.dst = dst_data + cc;
                         arg.mean = static_cast<float*>(&mean);
-                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(float));
-                        arg.dst_stride = static_cast<size_t>(blk_size * sizeof(float));
+                        arg.src_stride = static_cast<size_t>(blk_size * sizeof(in_data_t));
+                        arg.dst_stride = static_cast<size_t>(blk_size * sizeof(out_data_t));
                         arg.work_amount = static_cast<size_t>(C2 / blk_size);
                         (*mvn_kernel)(&arg);
 
@@ -881,8 +967,8 @@ void MKLDNNMVNNode::mvn_pln(const float* src_data, float* dst_data, const SizeVe
                     arg.src = src_data + cc;
                     arg.dst = dst_data + cc;
                     arg.sum = static_cast<float*>(&mean);
-                    arg.src_stride = static_cast<size_t>(blk_size * sizeof(float));
-                    arg.dst_stride = static_cast<size_t>(blk_size * sizeof(float));
+                    arg.src_stride = static_cast<size_t>(blk_size * sizeof(in_data_t));
+                    arg.dst_stride = static_cast<size_t>(blk_size * sizeof(out_data_t));
                     arg.work_amount = static_cast<size_t>(C2 / blk_size);
                     (*mvn_mean_kernel)(&arg);
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
@@ -506,12 +506,8 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
     }
 
     if (!mayiuse(avx512_core_bf16)) {
-        bool hasBF16 = false;
-        if (inputPrecision == Precision::BF16)
-            hasBF16 = true;
-
-        if (outputPrecision == Precision::BF16 || hasBF16)
-            THROW_IE_EXCEPTION << "MVN node with name `" << getName() << "` doesn't support BF16 precision on this target.";
+        if (outputPrecision == Precision::BF16)
+            outputPrecision = Precision::FP32;
     }
 
     auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(inputPrecision);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
@@ -486,7 +486,6 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
     setPostOps(attr, true);
 
     Precision inputPrecision = getCnnLayer()->insData[0].lock()->getPrecision();
-    if (inputPrecision == Precision::BF16) inputPrecision =  Precision::FP32;
     Precision outputPrecision = getCnnLayer()->outData[0]->getPrecision();
 
     if (!fusedWith.empty()) {
@@ -495,7 +494,6 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
             outputPrecision = lastFusedLayer->outData[0]->getPrecision();
         }
     }
-    if (outputPrecision == Precision::BF16) outputPrecision = Precision::FP32;
 
     if (getParentEdgeAt(0)->getDims().ndims() < 4 || getParentEdgeAt(0)->getDims().ndims() > 5
         || across_channels != 0 || normalize_variance != 1) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.h
@@ -81,7 +81,8 @@ public:
     }
 
 private:
-    void mvn_pln(const float* src_data, float* dst_data, const InferenceEngine::SizeVector& dims);
+    template <typename in_data_t, typename out_data_t>
+    void mvn_pln(const in_data_t* src_data, out_data_t* dst_data, const InferenceEngine::SizeVector& dims);
 
     template <typename in_data_t, typename out_data_t>
     void mvn_blk(const in_data_t* src_data, out_data_t* dst_data, const InferenceEngine::SizeVector& dims);

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -68,7 +68,7 @@ std::vector<std::string> disabledTestPatterns() {
     if (!InferenceEngine::with_cpu_x86_bfloat16()) {
         // on platforms which do not support bfloat16, we are disabling bf16 tests since there are no bf16 primitives,
         // tests are useless on such platforms
-       retVector.emplace_back(R"(.*netPRC=BF16.*)");
+       retVector.emplace_back(R"(.*BF16.*)");
     }
 
     return retVector;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
@@ -46,6 +46,9 @@ protected:
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
+        // Withing the test scope we don't need any implicit bf16 optimisations, so let's run the network as is.
+        configuration.insert({PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO});
+
         InferenceEngine::SizeVector inputShapes;
         InferenceEngine::Precision netPrecision;
         bool acrossChanels, normalizeVariance;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
@@ -1,0 +1,186 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <single_layer_tests/mvn.hpp>
+#include "ngraph_functions/builders.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+typedef std::tuple<
+        LayerTestsDefinitions::mvnParams,
+        CPUSpecificParams,
+        Precision, // CNNNetwork input precision
+        Precision> // CNNNetwork output precision
+MvnLayerCPUTestParamSet;
+
+class MvnLayerCPUTest : public testing::WithParamInterface<MvnLayerCPUTestParamSet>,
+                        virtual public LayerTestsUtils::LayerTestsCommon, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<MvnLayerCPUTestParamSet> obj) {
+        LayerTestsDefinitions::mvnParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        Precision inputPrecision, outputPrecision;
+        std::tie(basicParamsSet, cpuParams, inputPrecision, outputPrecision) = obj.param;
+
+        std::ostringstream result;
+        result << LayerTestsDefinitions::MvnLayerTest::getTestCaseName(testing::TestParamInfo<LayerTestsDefinitions::mvnParams>(
+                basicParamsSet, 0));
+
+        result << "_" << "CNNInpPrc=" << inputPrecision.name();
+        result << "_" << "CNNOutPrc=" << outputPrecision.name();
+
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        LayerTestsDefinitions::mvnParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::tie(basicParamsSet, cpuParams, inPrc, outPrc) = this->GetParam();
+
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+
+        InferenceEngine::SizeVector inputShapes;
+        InferenceEngine::Precision netPrecision;
+        bool acrossChanels, normalizeVariance;
+        double eps;
+        std::tie(inputShapes, netPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = basicParamsSet;
+        auto netPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto param = ngraph::builder::makeParams(netPrc, {inputShapes});
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
+        auto mvn = ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
+
+        std::string strExpectedPrc;
+        if (Precision::BF16 == inPrc) {
+            strExpectedPrc = "BF16";
+        } else if (Precision::FP32 == inPrc) {
+            strExpectedPrc = "FP32";
+        }
+
+        std::string isaType;
+        if (with_cpu_x86_avx512f()) {
+            isaType = "jit_avx512";
+        } else if (with_cpu_x86_avx2()) {
+            isaType = "jit_avx2";
+        } else if (with_cpu_x86_sse42()) {
+            isaType = "jit_sse42";
+        } else {
+            isaType = "ref";
+        }
+        selectedType = isaType + "_" + strExpectedPrc;
+
+        threshold = 0.015f; //slightly increase threshold
+
+        mvn->get_rt_info() = getCPUInfo();
+
+        function = std::make_shared<ngraph::Function>(results, param, "mvn");
+    }
+};
+
+TEST_P(MvnLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckCPUImpl(executableNetwork, "MVN");
+}
+
+namespace {
+const std::vector<std::vector<size_t>> inputShapes_3D = {
+        {1, 32, 17},
+        {1, 37, 9},
+};
+
+const std::vector<std::vector<size_t>> inputShapes_4D = {
+        {1, 16, 5, 8},
+        {2, 19, 5, 10},
+        {7, 32, 2, 8},
+        {5, 8, 3, 5},
+        {4, 41, 6, 9}
+};
+
+const std::vector<std::vector<size_t>> inputShapes_5D = {
+        {1, 32, 8, 1, 6},
+        {1, 9, 1, 15, 9},
+        {6, 64, 6, 1, 18},
+        {2, 31, 2, 9, 1},
+        {10, 16, 5, 10, 6}
+};
+
+const std::vector<bool> acrossChannels = {
+        true,
+        false
+};
+
+const std::vector<bool> normalizeVariance = {
+        true,
+        false
+};
+
+const std::vector<double> epsilon = {
+        0.000000001
+};
+
+std::vector<Precision> inpOutPrc = {Precision::BF16, Precision::FP32};
+
+std::vector<CPUSpecificParams> cpuParams_4D = {
+        CPUSpecificParams({nChw16c}, {nChw16c}, {}, {}),
+        CPUSpecificParams({nchw}, {nchw}, {}, {})
+};
+
+std::vector<CPUSpecificParams> cpuParams_5D = {
+        CPUSpecificParams({nCdhw16c}, {nCdhw16c}, {}, {}),
+        CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})
+};
+
+const auto Mvn3D = ::testing::Combine(
+        ::testing::Combine(
+            ::testing::ValuesIn(inputShapes_3D),
+            ::testing::Values(InferenceEngine::Precision::FP32),
+            ::testing::ValuesIn(acrossChannels),
+            ::testing::ValuesIn(normalizeVariance),
+            ::testing::ValuesIn(epsilon),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::Values(emptyCPUSpec),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(CompareWithRefs_3D, MvnLayerCPUTest, Mvn3D, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn4D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapes_4D),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::ValuesIn(acrossChannels),
+                ::testing::ValuesIn(normalizeVariance),
+                ::testing::ValuesIn(epsilon),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(CompareWithRefs_4D, MvnLayerCPUTest, Mvn4D, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn5D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapes_5D),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::ValuesIn(acrossChannels),
+                ::testing::ValuesIn(normalizeVariance),
+                ::testing::ValuesIn(epsilon),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(CompareWithRefs_5D, MvnLayerCPUTest, Mvn5D, MvnLayerCPUTest::getTestCaseName);
+
+
+} // namespace
+} // namespace CPULayerTestsDefinitions


### PR DESCRIPTION
MVN now supports bfloat16 input and output precisions. Also CPU specific single layer test for the MVN layer has been created.